### PR TITLE
Added `when`  method for conditional execution

### DIFF
--- a/src/WorkflowManager.php
+++ b/src/WorkflowManager.php
@@ -8,4 +8,11 @@ use Safemood\Workflow\Traits\WorkflowTraits;
 abstract class WorkflowManager implements WorkflowInterface
 {
     use WorkflowTraits;
+
+    protected function when(bool $condition, callable $callback)
+    {
+        if ($condition) {
+            $callback();
+        }
+    }
 }

--- a/tests/Helpers/DummyWorkflow.php
+++ b/tests/Helpers/DummyWorkflow.php
@@ -28,15 +28,12 @@ class DummyWorkflow extends WorkflowManager
 
         $this->addAfterAction(new DummyJob());
 
-        if ($this->trackEvents) {
-            $this->trackAllEvents();
-        }
-
-        if ($this->registerObservers) {
+        $this->when($this->trackEvents, fn () => $this->trackAllEvents());
+        $this->when($this->registerObservers, function () {
             $this->registerObservers([
                 DummyModel::class => DummyModelObserver::class,
             ]);
-        }
+        });
 
     }
 }


### PR DESCRIPTION
**PR Description:**

This PR introduces a new method for conditional execution within the workflow management system. The `when` method allows the execution of a callback based on a provided condition, enhancing the flexibility and readability of workflow definitions.

**Changes Include:**

- Added `when` method for conditional execution.
- Updated `DummyWorkflow` to utilize the `when` method for tracking events and registering observers conditionally.

**Example Usage:**
```php
$this->when(false, function () {
    $this->trackAllEvents();
});

$this->when(true, function () {
    $this->registerObservers([
        DummyModel::class => DummyModelObserver::class,
    ]);
});

$this->when(true, function () {
    $this->addBeforeActions([
        new DummyAction(),
        new DummyAction(),
    ]);
});
